### PR TITLE
ISSUE-7: MPChangesConsumer hangs on exceptions

### DIFF
--- a/cchain/consumers/mp.py
+++ b/cchain/consumers/mp.py
@@ -24,10 +24,17 @@ class MPFeedReader(base.ChangesFeedReader):
 
         self._reader_process.start()
 
+        # The main process will only write to the pipe, so close the
+        # output end.
+        self._changes_out.close()
+
     def read_changes(self):
         """Reads changes from self._changes_out and processes them as normal.
 
         """
+
+        # Close the input end, because we will read from the pipe here.
+        self._changes_in.close()
 
         while True:
             try:


### PR DESCRIPTION
- Close pipe ends that are not in use to prevent the main process from
  hanging when the child (i.e., change reader) dies.
