### PR TITLE
Run persist tasks in parallel.

### DIFF
--- a/cchain/consumers/base.py
+++ b/cchain/consumers/base.py
@@ -60,9 +60,11 @@ class ChangesFeedReader(pycouchdb.feedreader.BaseFeedReader):
             return
 
         try:
-            _, last_seq = self._processor.process_changes(
+            processed_changes, last_seq = self._processor.process_changes(
                 self._buffer
             )
+
+            self._processor.persist_changes(processed_changes)
         except processors_exceptions.ProcessingError:
             raise pycouchdb.exceptions.FeedReaderExited
 

--- a/cchain/consumers/mp.py
+++ b/cchain/consumers/mp.py
@@ -1,6 +1,15 @@
+import datetime
+import Queue
+
+import futures
+import logging
 import multiprocessing
+import pycouchdb
 
 from . import base
+
+
+logger = logging.getLogger(__name__)
 
 
 class MPFeedReader(base.ChangesFeedReader):
@@ -8,6 +17,8 @@ class MPFeedReader(base.ChangesFeedReader):
     incoming _changes.
 
     """
+
+    task_queue_length = 10
 
     def __init__(self, **kwargs):
 
@@ -19,7 +30,7 @@ class MPFeedReader(base.ChangesFeedReader):
         ).__init__(**kwargs)
 
         self._reader_process = multiprocessing.Process(
-            target=self.read_changes
+            target=self.start_reading_changes
         )
 
         self._reader_process.start()
@@ -28,15 +39,94 @@ class MPFeedReader(base.ChangesFeedReader):
         # output end.
         self._changes_out.close()
 
+    def _track_seq(self):
+        """Reads persist tasks from the queue and keeps track of the
+        last change seqence.
+
+        """
+
+        while True:
+
+            logger.debug('Waiting for persist task...')
+            (processed_changes, last_seq) = self._persist_queue.get()
+
+            if processed_changes is None:
+                logger.info('Terminating sequence tracker.')
+
+            logger.debug('Got processed_changes with last seq: %s', last_seq)
+            # If this succeeds, go on and save the sequence to the file,
+            # otherwise break spectacularly.
+            self._processor.persist_changes(processed_changes)
+
+            if last_seq is not None:
+                self._seqtracker.put_seq(last_seq)
+
+    def flush_buffer(self):
+        if not self._buffer:
+            return
+
+        try:
+            processed_changes, last_seq = self._processor.process_changes(
+                self._buffer
+            )
+
+            self._buffer = []
+            self._last_flush_time = datetime.datetime.now()
+
+            logger.info(
+                'Putting processed data in the queue, last_seq: %s',
+                last_seq
+            )
+
+            self._persist_queue.put((processed_changes, last_seq))
+
+        except:
+            logger.exception('Error while processing changes!')
+            raise pycouchdb.exceptions.FeedReaderExited
+
+    def start_reading_changes(self):
+         # Close the input end, because we will read from the pipe here.
+        self._changes_in.close()
+
+        # The queue to store `persist_changes` tasks on.
+        self._persist_queue = Queue.Queue(maxsize=self.task_queue_length)
+
+        self._persist_executor = futures.ThreadPoolExecutor(
+            max_workers=1
+        )
+
+        # Start the future for tracking the sequence.
+        self._seq_tracking_future = self._persist_executor.submit(
+            self._track_seq
+        )
+
+        # When tracker dies, purge the queue to prevent deadlocks.
+        # TODO(kris): Sort it out properly.
+        def purge_queue(_):
+            while True:
+                self._persist_queue.get_nowait()
+
+        # Purge the queue if nobody is reading from it anymore.
+        self._seq_tracking_future.add_done_callback(
+            purge_queue
+        )
+
+        # Now, read changes until you die.
+        try:
+            self.read_changes()
+        except:
+            logger.exception('Error reading changes! Terminating.')
+
+        # Write a termination sequence to the queue, so that the sequence
+        # tracker can exit.
+        self._persist_queue.put((None, None))
+
     def read_changes(self):
         """Reads changes from self._changes_out and processes them as normal.
 
         """
 
-        # Close the input end, because we will read from the pipe here.
-        self._changes_in.close()
-
-        while True:
+        while self._seq_tracking_future.running():
             try:
                 change_line = self._changes_out.recv()
             except EOFError:

--- a/cchain/processors/base.py
+++ b/cchain/processors/base.py
@@ -13,6 +13,17 @@ logger = logging.getLogger(__name__)
 
 class BaseChangesProcessor(object):
 
+    def persist_changes(self, processed_changes):
+        """Override this with code that persists your processed changes.
+        This should either succeed or raise an exception.
+
+        :param processed_changes: changes returned by the `process_changes`
+            method
+
+        :returns: None
+
+        """
+
     def process_changes(self, changes_buffer):
         """Extracts processed docs from the changes buffer.
 
@@ -116,7 +127,7 @@ class BaseDocChangesProcessor(BaseChangesProcessor):
 
 class BaseESChangesProcessor(BaseDocChangesProcessor):
 
-    def __init__(self, es_urls, es_index, **kwargs):
+    def __init__(self, es_urls, es_index, bulk_timeout=60, **kwargs):
         """
 
         :param es_urls: Urls of ES nodes.
@@ -129,6 +140,7 @@ class BaseESChangesProcessor(BaseDocChangesProcessor):
             self
         ).__init__(**kwargs)
 
+        self._bulk_timeout = bulk_timeout
         self._es = elasticsearch.Elasticsearch(es_urls)
         self._es_index = es_index
 

--- a/cchain/processors/couchdb.py
+++ b/cchain/processors/couchdb.py
@@ -48,11 +48,9 @@ class SimpleCouchdbChangesProcessor(base.BaseCouchdbChangesProcessor):
         if not processed_changes:
             return processed_changes, last_seq
 
-        self.bulk_save_changes(processed_changes)
-
         return processed_changes, last_seq
 
-    def bulk_save_changes(self, processed_changes):
+    def persist_changes(self, processed_changes):
         """Saves the processed changes in bulk.
 
         :param processed_changes: a list of (doc, rev, seq) tuples.

--- a/cchain/processors/entity.py
+++ b/cchain/processors/entity.py
@@ -54,13 +54,7 @@ class RedisEntityProcessor(base.BaseChangesProcessor):
 
         return (doc_id, rev, seq, )
 
-    def process_changes(self, changes_buffer):
-
-        processed_changes, last_seq = super(
-            RedisEntityProcessor,
-            self
-        ).process_changes(changes_buffer)
-
+    def persist_changes(self, processed_changes):
         now = datetime.datetime.now()
         timestamp = time.mktime(now.timetuple())
 
@@ -80,5 +74,12 @@ class RedisEntityProcessor(base.BaseChangesProcessor):
             aggregate='MIN'
         )
         redis_server.delete([source_set_name])
+
+    def process_changes(self, changes_buffer):
+
+        processed_changes, last_seq = super(
+            RedisEntityProcessor,
+            self
+        ).process_changes(changes_buffer)
 
         return processed_changes, last_seq

--- a/cchain/processors/s3.py
+++ b/cchain/processors/s3.py
@@ -54,13 +54,7 @@ class SimpleS3ChangesProcessor(base.BaseS3ChangesProcessor):
 
         return key_name
 
-    def process_changes(self, changes_buffer):
-
-        processed_changes, last_seq = super(
-            SimpleS3ChangesProcessor,
-            self
-        ).process_changes(changes_buffer)
-
+    def persist_changes(self, processed_changes):
         logger.debug(
             'Starting %d tasks to store documents...',
             len(processed_changes)
@@ -75,5 +69,12 @@ class SimpleS3ChangesProcessor(base.BaseS3ChangesProcessor):
 
         for key_name in key_names:
             logger.debug('Key created in s3: %s', key_name)
+
+    def process_changes(self, changes_buffer):
+
+        processed_changes, last_seq = super(
+            SimpleS3ChangesProcessor,
+            self
+        ).process_changes(changes_buffer)
 
         return processed_changes, last_seq

--- a/tests/processors/es.py
+++ b/tests/processors/es.py
@@ -89,5 +89,6 @@ class SimpleESChangesProcessorTestCase(
 
         self.processor._es.bulk.assert_called_once_with(
             self.expected_bulk_ops,
-            refresh=True
+            timeout=self.processor._bulk_timeout,
+            request_timeout=self.processor._bulk_timeout
         )

--- a/tests/processors/mixins.py
+++ b/tests/processors/mixins.py
@@ -11,6 +11,8 @@ class ProcessChangesTestMixin(object):
             self.samples
         )
 
+        self.processor.persist_changes(processed_changes)
+
         self.assertEqual(seq, self.samples[-1]['seq'])
 
         for sample, processed_change in zip(


### PR DESCRIPTION
- Factor out a dedicated `persist_changes` method to be able to
  parallelize persistence tasks.
- Use a threadpool exectutor to run persist changes in a dedicated
  thread (but still one batch at a time).
- Stop reading changes if seq tracker died.
- Set a high (60s) default timeout for bulk ES requests.
- Don't refresh the index after each operation to speed up ingestion.
- Fix tests.

**WARNING**:
  This is still experimental. Things may hang. Use at own risk.
